### PR TITLE
Fix broken typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,12 @@ import * as React from "react";
 declare class ThreeBoxComments extends React.Component<ThreeBoxCommentsProps, any> { }
 
 interface ThreeBoxCommentsProps {
-  box?: [any];
-  loginFunction?: [any];
-  ethereum?: [any];
-  threadOpts?: [any];
-  currentUser3BoxProfile?: [any];
-  spaceOpts?: [any];
+  box?: any;
+  loginFunction?: any;
+  ethereum?: any;
+  threadOpts?: any;
+  currentUser3BoxProfile?: any;
+  spaceOpts?: any;
   members?: boolean;
   useHovers?: boolean;
   showCommentCount?: number;


### PR DESCRIPTION
Many of the ThreeBoxCommentsProps were typed as a tuple [any] when they should just be any